### PR TITLE
[v4.13] Use CEL filtering to scope each pipeline to its directory

### DIFF
--- a/.tekton/v413-cnv-fbc-pull-request.yaml
+++ b/.tekton/v413-cnv-fbc-pull-request.yaml
@@ -9,6 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: '[pull_request]'
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && ("v4.13/*".pathChanged() || ".tekton/*".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cnv-fbc-v4-13

--- a/.tekton/v413-cnv-fbc-push.yaml
+++ b/.tekton/v413-cnv-fbc-push.yaml
@@ -8,6 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: '[push]'
     pipelinesascode.tekton.dev/on-target-branch: '[main]'
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && ("v4.13/*".pathChanged() || ".tekton/*".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: cnv-fbc-v4-13


### PR DESCRIPTION
Use CEL filtering annotation (see:
https://pipelinesascode.com/docs/guide/authoringprs/#advanced-event-matching ) to scope each application just to its specific directory (and the pipeline ones for consistency).