### PR TITLE
Force opm v1.27.1 for backward compatibility

### DIFF
--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Sanity Checks
     runs-on: ubuntu-latest
     env:
-      OPM_VERSION: v1.29.0
+      OPM_VERSION: v1.27.1
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Catalogs generated by opm v1.28.0 and newer
are not compatible with OCP v4.13 and older.
Force opm v1.27.1 for backward compatibily.

TODO: use OCP dependant opm version