### PR TITLE
[v4.13] Revert to hco-bundle-registry:v4.13.7.rhel9-315

### DIFF
--- a/v4.13/graph.yaml
+++ b/v4.13/graph.yaml
@@ -95,5 +95,5 @@ image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rh
 # hco-bundle-registry v4.13.6.rhel9-102
 ---
 schema: olm.bundle
-image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:ddca8ffca50294f1a1c123289b178f83dca1ec4678956b0f6be2c6d06d050164
-# hco-bundle-registry v4.13.7.rhel9-392
+image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:e2eb0649472b16b0a38284e61df3a01eee7c72d8948dda7c6b29ce79e4e59397
+# hco-bundle-registry v4.13.7.rhel9-315


### PR DESCRIPTION
manual update to get ready to push to production.