### PR TITLE
[v4.15] Add hco-bundle-registry:v4.15.0.rhel9-2585

### DIFF
--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -111,5 +111,5 @@ image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rh
 # hco-bundle-registry v4.14.3.rhel9-155
 ---
 schema: olm.bundle
-image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:3869c1828210e78c0090dad70e4d7b21c8de7f4c47ba4258bc3e38eb90871eb2
-# hco-bundle-registry v4.15.0.rhel9-2672
+image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:eecd15154d57ac46afdb7121a281bb1beea682a8b56c37af02401ac787569a5a
+# hco-bundle-registry v4.15.0.rhel9-2585


### PR DESCRIPTION
Correctly using registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15 as its base image.