### PR TITLE
[v4.16] Revert back to `registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15`

### DIFF
--- a/v4.16/catalog.Dockerfile
+++ b/v4.16/catalog.Dockerfile
@@ -1,7 +1,7 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-# TODO: move to registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16 once available
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.16
+# TODO: update tag to v4.16 once available
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.15
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Apparently, RHTAP/KonFlux can't use the brew registry in the release pipeline, so we're reverting back to production v4.15 to unblock 4.16 stage releases