### PR TITLE
[v4.15] Get ready to push out v4.99.0.rhel9-316 on dev-preview channel

### DIFF
--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -48,8 +48,6 @@ entries:
     skipRange: '>=4.14.4 <4.15.0'
   - name: kubevirt-hyperconverged-operator.v4.15.1
     replaces: kubevirt-hyperconverged-operator.v4.15.0
-  - name: kubevirt-hyperconverged-operator.v4.15.2
-    replaces: kubevirt-hyperconverged-operator.v4.15.1
 name: stable
 package: kubevirt-hyperconverged
 schema: olm.channel
@@ -123,5 +121,12 @@ image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rh
 # hco-bundle-registry v4.15.1.rhel9-132
 ---
 schema: olm.bundle
-image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:02486e25a0949bbe20df39f79f9060cde477a78a4350de5c841f08ce70355de5
-# hco-bundle-registry v4.15.2.rhel9-183
+image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:f8b4ea55f6e416e4eaf7b5cd4ab564c12af292581fe12b426ca2adbfe29d8a37
+# hco-bundle-registry v4.99.0.rhel9-316
+---
+entries:
+  - name: kubevirt-hyperconverged-operator.v4.99.0-0.1713770549
+    skipRange: <v4.99.0
+name: dev-preview
+package: kubevirt-hyperconverged
+schema: olm.channel


### PR DESCRIPTION
Get ready to push out v4.99.0.rhel9-316 on dev-preview channel without pushing out any v4.15.2 on the stable one.