### PR TITLE
ignore 4.99 modification on check-prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sanity-brew:
 
 check-prod:
 	./generate-fbc.sh --init-basic-all
-	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" || true
-	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" || true | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
+	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
+	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
 
 .PHONY: sanity sanity-brew check-prod

--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -3,7 +3,7 @@ name: kubevirt-hyperconverged
 defaultChannel: stable
 ---
 entries:
-  - name: kubevirt-hyperconverged-operator.v4.99.0-0.1713770549
+  - name: kubevirt-hyperconverged-operator.v4.99.0-0.1716162689
     skipRange: <v4.99.0
 name: dev-preview
 package: kubevirt-hyperconverged
@@ -134,5 +134,5 @@ image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rh
 # hco-bundle-registry v4.15.2.rhel9-335
 ---
 schema: olm.bundle
-image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:f8b4ea55f6e416e4eaf7b5cd4ab564c12af292581fe12b426ca2adbfe29d8a37
-# hco-bundle-registry v4.99.0.rhel9-316
+image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:3b9c9abc944e7b641f3ba907fd07a19d1152c0a6c73922c3221184f352189995
+# hco-bundle-registry v4.99.0.rhel9-440


### PR DESCRIPTION
4.99 bundles are designed to be replaced with fresh ones in the dev-preview channel, not being accumulated over time