### PR TITLE
skip check-prod when only .tekton/ is touched

### DIFF
--- a/.github/workflows/check-prod.yaml
+++ b/.github/workflows/check-prod.yaml
@@ -3,8 +3,12 @@ name: Sanity Checks
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '.tekton/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '.tekton/**'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Use paths-ignore directive to avoid running
check-prod sanity actions when the PR contains
only changes to files under .tekton/ .
This will prevent an outdated configuration of the repo
to block pipelines updates that can then eventually
block repo updates with a deadlock.