### PR TITLE
Tolerate fixes on `skipRange: <v4.99.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sanity-brew:
 
 check-prod:
 	./generate-fbc.sh --init-basic-all
-	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
-	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
+	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
+	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
 
 .PHONY: sanity sanity-brew check-prod


### PR DESCRIPTION
hco-bundle-registry v4.99.0.rhel9-316
got erroneously shipped with:
skipRange: <v4.99.0
while the correct syntax would be:
skipRange: <4.99.0

Let's tolerate PRs that are going to fix it
in the next release.
Once this will be effectively fixed also in production, this PR could PR reverted.