### PR TITLE
Revert "Use operator registry image of 4.17 for v4.17"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sanity-brew:
 
 check-prod:
 	./generate-fbc.sh --init-basic-all
-	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v -e "^+$$" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
-	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v -e "^+$$" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
+	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
+	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
 
 .PHONY: sanity sanity-brew check-prod

--- a/v4.17/catalog.Dockerfile
+++ b/v4.17/catalog.Dockerfile
@@ -1,6 +1,8 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.17
+# TODO: move to v4.17 once registry.redhat.io/redhat/redhat-operator-index:v4.17
+# will be initialized
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.16
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Reverts openshift-cnv/cnv-fbc#9826

looks like this change has caused a deletion of 4.17 graph.yaml:
https://github.com/openshift-cnv/cnv-fbc/commit/f2dbde1c8ac5afe107911f2e35d2afd2fde0ba09