### PR TITLE
[v4.17] initialize v4.17

### DIFF
--- a/v4.17/catalog.Dockerfile
+++ b/v4.17/catalog.Dockerfile
@@ -1,8 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-# TODO: move to v4.17 once registry.redhat.io/redhat/redhat-operator-index:v4.17
-# will be initialized
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.16
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.17
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
v4.17/graph.yaml is already aligned with
what on production catalog for v4.16.
No need to update it in this case.