### PR TITLE
Fix check-prod for v4.99 skipRange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sanity-brew:
 
 check-prod:
 	./generate-fbc.sh --init-basic-all
-	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
-	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
+	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
+	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
 
 .PHONY: sanity sanity-brew check-prod


### PR DESCRIPTION
In the past we uncorrectly used
`skipRange: <v4.99.0` for v4.99 sprintly releases. Now we are more correctly setting something like
`skipRange: <4.99.0-0.1724436925`.
Let's fix `make check-prod` to tollerate both
the expressions.