### PR TITLE
Revert "Update Konflux references to d959d58"

### DIFF
--- a/.tekton/v412-cnv-fbc-pull-request.yaml
+++ b/.tekton/v412-cnv-fbc-pull-request.yaml
@@ -387,7 +387,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v412-cnv-fbc-push.yaml
+++ b/.tekton/v412-cnv-fbc-push.yaml
@@ -380,7 +380,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v413-cnv-fbc-pull-request.yaml
+++ b/.tekton/v413-cnv-fbc-pull-request.yaml
@@ -387,7 +387,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v413-cnv-fbc-push.yaml
+++ b/.tekton/v413-cnv-fbc-push.yaml
@@ -380,7 +380,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v414-cnv-fbc-pvfh-pull-request.yaml
+++ b/.tekton/v414-cnv-fbc-pvfh-pull-request.yaml
@@ -387,7 +387,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v414-cnv-fbc-pvfh-push.yaml
+++ b/.tekton/v414-cnv-fbc-pvfh-push.yaml
@@ -380,7 +380,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v415-cnv-fbc-gnu1-pull-request.yaml
+++ b/.tekton/v415-cnv-fbc-gnu1-pull-request.yaml
@@ -387,7 +387,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v415-cnv-fbc-gnu1-push.yaml
+++ b/.tekton/v415-cnv-fbc-gnu1-push.yaml
@@ -380,7 +380,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v416-cnv-fbc-pull-request.yaml
+++ b/.tekton/v416-cnv-fbc-pull-request.yaml
@@ -417,7 +417,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v416-cnv-fbc-push.yaml
+++ b/.tekton/v416-cnv-fbc-push.yaml
@@ -411,7 +411,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v417-cnv-fbc-pull-request.yaml
+++ b/.tekton/v417-cnv-fbc-pull-request.yaml
@@ -417,7 +417,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/v417-cnv-fbc-push.yaml
+++ b/.tekton/v417-cnv-fbc-push.yaml
@@ -411,7 +411,7 @@ spec:
         - name: name
           value: fbc-validation
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:d959d581e4bfcb065e7ceaf9cd2e485e1d3e4de1185b825b5f7b85a9e61629ba
+          value: quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation:0.1@sha256:ced2eff954082a4444eb06238255fa19da42cb52af04dd99a9de159beced270f
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
This reverts commit 513b75e5e45e4f38da6f4f309239af63aff2573d.

quay.io/redhat-appstudio-tekton-catalog/task-fbc-validation d959d58 is failing extracting the target OCP release from the BASE_IMAGE value. Let's skip it until it's fixed, see:
https://github.com/konflux-ci/build-definitions/pull/1373