### PR TITLE
[check-prod] decouple versions while comparing with prod

### DIFF
--- a/.github/workflows/check-prod.yaml
+++ b/.github/workflows/check-prod.yaml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 3
 
       - name: Prepare auth file
         run: echo ${AUTH_FILE_CONTENT} | base64 -d > ${REGISTRY_AUTH_FILE}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+auth.json
+.docker/config.json

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ sanity-brew:
 	git diff --exit-code
 
 check-prod:
-	./generate-fbc.sh --init-basic-all
-	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}'
-	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=3} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
+	for v in $$(git diff --name-only --name-only HEAD HEAD~1 | grep graph.yaml); do echo "Comparing $${v%/*} with prod"; ./generate-fbc.sh --init-basic "$${v%/*}" yq; done
+	git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=2} skip {skip--; next} {print}'
+	NUMLL=$$(git diff HEAD --no-ext-diff --patience --unified=0 -a --no-prefix "v4.*/graph.yaml" | grep -e "^+" | grep -v -e "^+++" | grep -v "skipRange: <v4.99.0" | grep -v "skipRange: <4.99.0" | awk '/v4.99.0-/ {skip=2} skip {skip--; next} {print}' | wc -l) && echo "Lost Lines: $$NUMLL" && exit $$NUMLL
 
 .PHONY: sanity sanity-brew check-prod


### PR DESCRIPTION
Till now, make check-prod was comparing all the versions against prod in a single execution so a broken
version was blocking also all
the other y-streams.
Let's decouple it checking only the versions touched in the PR.