### PR TITLE
Configure mintmaker to avoid bumping ose-operator-registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+  ],
+  "ignoreDeps": [
+    "registry.redhat.io/openshift4/ose-operator-registry",
+    "registry.redhat.io/openshift4/ose-operator-registry-rhel9",
+    "brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9"
+  ]
+}


### PR DESCRIPTION
The tag specified for the ose-operator-registry image, is also implicitly used to select the target OCP
minor we intend to release to.
See: https://konflux-ci.dev/architecture/ADR/0026-specifying-ocp-targets-for-fbc.html Let's ensure that mintmaker is not going to bump
it to ensure we are going to release on the
expected OCP minor.