### PR TITLE
Use ose-operator-registry-rhel9 from prod

### DIFF
--- a/v4.16/catalog.Dockerfile
+++ b/v4.16/catalog.Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.16
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]

--- a/v4.17/catalog.Dockerfile
+++ b/v4.17/catalog.Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.17
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Images:
- registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
- registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17 

are now publicly available.
Use the released images from the prod registry.