### PR TITLE
Use --format in skopeo to extract container label  instead of using grep

### DIFF
--- a/generate-fbc.sh
+++ b/generate-fbc.sh
@@ -189,7 +189,7 @@ case $cmd in
       image=${line/image: /}
       echo "Processing $image"
       # shellcheck disable=SC2086
-      url=$(${SKOPEO_CMD} inspect --no-tags ${AUTH_FILE} "docker://$image" | grep "\"url\": ")
+      url=$(${SKOPEO_CMD} inspect --format "{{.Labels.url}}" ${AUTH_FILE} docker://"$image")
       tag1=${url/*\/images\/}
       tag=${tag1/\",/}
       sed -i -E "s|^( *)(image: )$image|\1\2$image\n\1# hco-bundle-registry $tag|g" "$frag"/graph.yaml
@@ -205,7 +205,7 @@ case $cmd in
         image=${line/image: /}
         echo "Processing $image"
 	# shellcheck disable=SC2086
-        url=$(${SKOPEO_CMD} inspect --no-tags ${AUTH_FILE} docker://"$image" | grep "\"url\": ")
+        url=$(${SKOPEO_CMD} inspect --format "{{.Labels.url}}" ${AUTH_FILE} docker://"$image")
         tag1=${url/*\/images\/}
         tag=${tag1/\",/}
         sed -i -E "s|^( *)(image: )$image|\1\2$image\n\1# hco-bundle-registry $tag|g" "$frag"/graph.yaml

--- a/generate-fbc.sh
+++ b/generate-fbc.sh
@@ -190,8 +190,7 @@ case $cmd in
       echo "Processing $image"
       # shellcheck disable=SC2086
       url=$(${SKOPEO_CMD} inspect --format "{{.Labels.url}}" ${AUTH_FILE} docker://"$image")
-      tag1=${url/*\/images\/}
-      tag=${tag1/\",/}
+      tag=${url/*\/images\/}
       sed -i -E "s|^( *)(image: )$image|\1\2$image\n\1# hco-bundle-registry $tag|g" "$frag"/graph.yaml
     done
     unsetBrew "${frag}" "$3"
@@ -206,8 +205,7 @@ case $cmd in
         echo "Processing $image"
 	# shellcheck disable=SC2086
         url=$(${SKOPEO_CMD} inspect --format "{{.Labels.url}}" ${AUTH_FILE} docker://"$image")
-        tag1=${url/*\/images\/}
-        tag=${tag1/\",/}
+        tag=${url/*\/images\/}
         sed -i -E "s|^( *)(image: )$image|\1\2$image\n\1# hco-bundle-registry $tag|g" "$frag"/graph.yaml
       done
       unsetBrew "${frag}" "$2"


### PR DESCRIPTION
@tiraboschi This change uses a `skopeo` formatting flag to extract the `url` field value without the need to generate all fields and then filter with grep.

I've tested it locally and it generated the same output.

PD: I've used this repo as reference to generate our equivalent RHDH `orchestrator-fbc` that I wanted to contribute something back after all the work I've benefited from by this repository.