### PR TITLE
RELEASE BLOCKER(March 1, 2025): add fbc-fips-check task to FBC pipeline

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -236,6 +236,31 @@ spec:
       operator: in
       values:
       - "true"
+  - name: fbc-fips-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check:0.1@sha256:03e9fd8c7c7fdcb8c965333fa7b2ea83e75da766f5ecd92cbc02ae4a92b2e247
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageDigestMirrorSet
+metadata:
+  name: example-mirror-set
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - quay.io/my-namespace/valid-repo
+      source: registry.redhat.io/unrelease-image/or-inaccessible-image


### PR DESCRIPTION
## Who should merge this?
All products building FBC fragments in Konflux are requested to merge this change irrespective of whether the product is intended for FIPS mode or not.

Beginning March 1, 2025, the fbc-fips-task is going to be a required task in the Konflux
pipeline. This means, your release will be blocked if this task is not present in your pipeline run.

## What if our product is not designed to operate in FIPS mode? Do we still need this task?
The answer is yes. If your product is not designed to operate in FIPS mode, the task will identify that and will
automatically skip the FIPS scan. However, the task still needs to be a part of your pipeline.

## What changes are included in this PR?
* This commit adds the fbc-fips-check task to your pipeline yaml.
* It also adds a file named `images-mirror-set.yaml` to your `.tekton` directory with an example in it. This file is an `ImageDigestMirrorSet`
  required by the task to access any unreleased bundle image in your FBC fragment. For example, say your FBC fragment contains an unreleased
  bundle pullspec `registry.redhat.io/my-namespace/my-repo` which will be unavailable at build time on the prod registry. You can specify a mirror
  like `quay.io/my-namespace/my-public-repo` from where the task can access the unreleased image. Mirrors can be specified for bundle images and
  their related images.

## What should we do after this PR is merged?
* Your bundle image pullspec and relatedImages pullspec are examples of pullspecs that may not be valid at build time
  but will only be pullable after the release. We recommend updating the `.tekton/images-mirror-set.yaml` file with mirrors for those
  pullspecs so the task can access them during build time. Please keep the `.tekton/images-mirror-set.yaml` file updated to avoid delays in releases.
* Add an ImagePullSecret for registry.redhat.io to your Konflux workspace. You can do this via Konflux UI.