### PR TITLE
[v4.15] Add a direct v4.14.6 -> v4.15.8

### DIFF
--- a/v4.15/graph.yaml
+++ b/v4.15/graph.yaml
@@ -62,9 +62,8 @@ entries:
       - name: kubevirt-hyperconverged-operator.v4.15.8
         replaces: kubevirt-hyperconverged-operator.v4.15.7
         skipRange: '>=4.14.10 <4.15.0'
-      - name: kubevirt-hyperconverged-operator.v4.15.9
-        replaces: kubevirt-hyperconverged-operator.v4.15.8
-        skipRange: '>=4.14.11 <4.15.0'
+        skips:
+          - kubevirt-hyperconverged-operator.v4.14.6
     name: stable
     package: kubevirt-hyperconverged
     schema: olm.channel
@@ -134,6 +133,3 @@ entries:
   - schema: olm.bundle
     image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:f8b4ea55f6e416e4eaf7b5cd4ab564c12af292581fe12b426ca2adbfe29d8a37
     # hco-bundle-registry v4.99.0.rhel9-316
-  - schema: olm.bundle
-    image: registry.redhat.io/container-native-virtualization/hco-bundle-registry-rhel9@sha256:4c8f7e457a61bdf4f17afebc555a9975afabe24f16b31246cde56ea3a2e77a94
-    # hco-bundle-registry v4.15.9.rhel9-218


### PR DESCRIPTION
As in https://github.com/openshift-cnv/cnv-fbc/pull/16778 to generate a fresh snapshot with FIPS validation task enabled.

Fixes: https://issues.redhat.com/browse/CNV-56950