### PR TITLE
Fix apply task update

### DIFF
--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -299,8 +299,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:

--- a/v4.19/rebuild.changelog
+++ b/v4.19/rebuild.changelog
@@ -4,4 +4,4 @@
 14/04/25 - Rebuild to test if FIPS still fails due to new container
 19/05/25 - Rebuild due to konflux failing after fips task update
 09/06/25 - Rebuild to test pipeline updates
-16/06/25 - Rebuild
+16/06/25 - Rebuild to test fix


### PR DESCRIPTION
An automatic mintmaker update bumped one of the tasks to 0.2
https://github.com/openshift-cnv/cnv-fbc/commit/a4535d6e806d98839d4519fa3bfa39f4451e39ed#diff-23c6b15db160f8e1c4b1a155c1a105208cf442b8769d82b7869bae6c00ff46d1R310-R311
But it didn't apply the migration steps
https://github.com/konflux-ci/build-definitions/blob/main/task/apply-tags/0.2/MIGRATION.md